### PR TITLE
Automated building of the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean clean-test clean-pyc clean-build docs help environment
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys
@@ -72,6 +72,18 @@ coverage: ## check code coverage quickly with the default Python
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html
+
+environment: ## create the environment for running the dashboard
+	@echo 'Creating the Conda/pip environment. This will take some time!'
+	@echo ''
+	@conda env create --force --file seamm-dashboard.yml
+	@echo ''
+	@echo 'Installing the Javascript, which will also take a couple minutes!'
+	@echo ''
+	@cd app/static && npm install
+	@echo ''
+	@echo 'To use the environment, type'
+	@echo '   conda activate seamm-dashboard'
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/app.rst

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -3,6 +3,8 @@ channels:
   - defaults
 dependencies:
   - python>=3.8
+  # Nodejs needed from anaconda, not pip, to have npm
+  - nodejs
   - pip
   - pip:
     - configargparse

--- a/seamm-dashboard.yml
+++ b/seamm-dashboard.yml
@@ -3,6 +3,8 @@ channels:
   - defaults
 dependencies:
   - python>=3.8
+  # Nodejs needed for npm! Pip version is different
+  - nodejs
   - pip
   - pip:
     - configargparse


### PR DESCRIPTION
This PR accomplishes two things:

1. Corrects the removal of `nodjs` from the environment. While it is not used in the Python it is needed for the Javascript, and in particular we need `npm` to install the Javascript. The Conda package contains `npm` (the PyPi package does not!)
2. Adds a target `environment` to the Makefile which creates the Conda/PIP environment and runs `npm install`