### PR TITLE
Cache fix

### DIFF
--- a/app/static/js/job_report.js
+++ b/app/static/js/job_report.js
@@ -1,21 +1,4 @@
 // You must include util.js on any page that uses this javascript file
-function inittable(data, div_id) {	
-    var my_table = $(`#${div_id}`).DataTable( {
-        "responsive": false,
-        "info": false,
-        "searching": false,
-        "lengthChange": false,
-        "orderable": false,
-        "paginate": false,
-        "aaData": data,
-        "columnDefs": [
-            { className: "sidebar-nav", "targets": [0, 1, 2, 3 ]}
-        ],
-        "autoWidth": false,
-    } );
-
-    return my_table
-}
 
 function buildTree(jobID) {
     var elements = [];
@@ -89,6 +72,15 @@ function loadGraph(nodeData) {
 }
 
 function loadTable(href) {
+    try {
+        table.destroy();
+        $('#csv-data tr').remove();
+        $('#csv-data thead').remove();
+        $('#csv-data tbody').remove();
+    } catch {
+        // Do nothing.
+    }
+
     var csvData = load_file(href, 'text')
     var separated = $.csv.toArrays(csvData)
 

--- a/app/static/js/job_report.js
+++ b/app/static/js/job_report.js
@@ -369,13 +369,24 @@ $(document).ready(function() {
             let arg = eval(contentFunctions[fileType]["load"][1])
             func(arg)
             
-            // Make refresh button work.
+            // Make file refresh button work.
             $("#refresh").click(
                 function() {
                 func(arg)
             })
         }
     });
+
+    // Make file list refresh button work.
+    $("#refresh-file-list").click(
+        function() {
+            document.getElementById("js-tree").classList.toggle("hidden")
+            newData = buildTree(jobID)
+            $('#js-tree').jstree(true).settings.core.data = newData;
+            $('#js-tree').jstree("refresh")
+            document.getElementById("js-tree").classList.toggle("hidden")
+        }
+    )
 
     toggleDivs(contentDivs)
     // Show content

--- a/app/static/js/job_report.js
+++ b/app/static/js/job_report.js
@@ -376,6 +376,12 @@ $(document).ready(function() {
             let func = contentFunctions[fileType]["load"][0]
             let arg = eval(contentFunctions[fileType]["load"][1])
             func(arg)
+            
+            // Make refresh button work.
+            $("#refresh").click(
+                function() {
+                func(arg)
+            })
         }
     });
 

--- a/app/static/js/jobs_list.js
+++ b/app/static/js/jobs_list.js
@@ -109,11 +109,30 @@ Do you wish to continue?
     }
 }
 
-function inittable(data) {	
+function inittable(api_url) {	
 
     var table = $('#jobs').DataTable( {
         "responsive": true,
-        "aaData": data,
+        "ajax": {
+            url: `api/${api_url}`,
+            async: false,
+            dataType: 'json',
+            dataSrc: function (data) {
+                let arrayReturn = [];
+                for (var i = 0, len = data.length; i < len; i++) {
+                    arrayReturn.push(
+                        ['', `<a class="nav-link p-0" href="/jobs/${data[i].id}" title="View Details">`+data[i].id+'</a>', 
+                        data[i].title, 
+                        data[i].status,
+                        data[i].submitted,
+                        data[i].started,
+                        data[i].finished
+                        ]
+                    )
+                }
+                return arrayReturn
+            }
+        },
         "select": {
             "style": "multi"
         },
@@ -167,6 +186,8 @@ function inittable(data) {
 
     table.buttons().container()
     .appendTo( '#jobs_wrapper .col-md-6:eq(1)' );
+
+    return table
 }
 
 function ajaxProjectDescription(project_url){
@@ -184,26 +205,11 @@ function ajaxProjectDescription(project_url){
 
 $(document).ready(function () {
     let api_url = location.href.split('#')[1];
-    var arrayReturn = [];
-    $.ajax({
-        url: `api/${api_url}`,
-        async: false,
-        dataType: 'json',
-        success: function (data) {
-            for (var i = 0, len = data.length; i < len; i++) {
-                arrayReturn.push(
-		    ['', `<a class="nav-link p-0" href="/jobs/${data[i].id}" title="View Details">`+data[i].id+'</a>', 
-		     data[i].title, 
-		     data[i].status,
-		     data[i].submitted,
-		     data[i].started,
-		     data[i].finished
-		    ]
-		)
-            }
-        inittable(arrayReturn);
-        }
-    });
+    let my_table = inittable(api_url);
+
+    // Add action to refresh button
+    $("#refresh").click(my_table.ajax.reload)
+
 
     let tableButtons = document.getElementsByClassName("dt-buttons")
     tableButtons[0].className = "row justify-content-end"
@@ -222,7 +228,6 @@ $(document).ready(function () {
       if (titleSplit.includes('projects')){
         titleSplit.pop()
         let my_url = titleSplit.join('/')
-        console.log(my_url)
         ajaxProjectDescription(my_url)
       }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -144,6 +144,10 @@
 
     <script>
       $('#ui-view').ajaxLoad();
+      // Prevent caching on ajax calls.
+      $.ajaxSetup ({
+        cache: false
+        });
     </script>
   </body>
 </html>

--- a/app/templates/jobs/job_report.html
+++ b/app/templates/jobs/job_report.html
@@ -23,7 +23,7 @@
         <div class= "card h-100 mb-0 border-0" id="outer-card">
           <div class="card-header btn">
             <span id="file-name">Click Files to view</span>
-            <button type="button" id="refresh" class="btn btn-sm btn-primary float-right" title="Refresh File Contents" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button>
+            <button type="button" id="refresh" class="btn btn-sm btn-outline-primary float-right" title="Refresh File Contents" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button>
           </div>
           <div id ="view-card-content" class="px-2 py-2 h-100">
             <div id='file-content' class="my-0 load-content" style="overflow-y: scroll;"></div>

--- a/app/templates/jobs/job_report.html
+++ b/app/templates/jobs/job_report.html
@@ -10,14 +10,14 @@
       <div class="col-sm-3">
         <div class="h4 mt-3" id="job-title"></div>
         <div>Status: <span id="job-status"></span></div>
-        <div class='h5 mt-3'>Browse files for job</div>
+        <div class='h5 mt-3'>Browse files for job<span><button type="button" id="refresh-file-list" class="btn btn btn-outline-primary float-right mb-3" title="Refresh File List" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button></span></div>
         <div class="input-group">
           <input type="text" class="form-control" placeholder="Search Files" id="search">
           <span class="input-group-btn">
             <button class="btn btn-primary" type="button" id="btn-search">Search</button>
           </span>
         </div>
-        <div style="margin:15px; white-space:pre-wrap; overflow-y: auto; overflow-x: auto;" id='js-tree' class="mh-100"></div>
+        <div style="margin:15px; white-space:pre-wrap; overflow-y: auto; overflow-x: auto;" id='js-tree' class="mh-100 animated fadeIn"></div>
       </div>
       <div class="col-sm-9 mt-3 mh-100 my-2" id="view-card">
         <div class= "card h-100 mb-0 border-0" id="outer-card">

--- a/app/templates/jobs/job_report.html
+++ b/app/templates/jobs/job_report.html
@@ -1,6 +1,7 @@
 <!-- Plugins and scripts required by this view-->
 <script src= "{{ url_for('static', filename='js/util.js') }}"></script>
 <script src= "{{ url_for('static', filename='js/job_report.js') }}"></script>
+<script src= "{{ url_for('static', filename='js/tooltips.js') }}"></script>
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom_flowchart.css') }}">
 
 
@@ -20,8 +21,9 @@
       </div>
       <div class="col-sm-9 mt-3 mh-100 my-2" id="view-card">
         <div class= "card h-100 mb-0 border-0" id="outer-card">
-          <div id="file-name" class="card-header btn">
-            Click Files to view
+          <div class="card-header btn">
+            <span id="file-name">Click Files to view</span>
+            <button type="button" id="refresh" class="btn btn-sm btn-primary float-right" title="Refresh File Contents" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button>
           </div>
           <div id ="view-card-content" class="px-2 py-2 h-100">
             <div id='file-content' class="my-0 load-content" style="overflow-y: scroll;"></div>

--- a/app/templates/jobs/jobs_list.html
+++ b/app/templates/jobs/jobs_list.html
@@ -1,6 +1,7 @@
 <script src="{{ url_for('static', filename='js/jobs_list.js') }}"></script>
+<script src= "{{ url_for('static', filename='js/tooltips.js') }}"></script>
 <div class="animated fadeIn sidebar-nav hidden" id="view">
-  <h1 class='pb-1'id='page-title'></h1>
+  <h1 class='pb-1'><span id='page-title'></span><button type="button" id="refresh" class="btn btn-lg btn-primary ml-4" title="Refresh Table" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button></h1>
   <div id="description" class='pb-3'></div>
     <table id="jobs" class="table table-responsive-sm table-bordered table-striped table-sm" style="width:100%">
       <thead>


### PR DESCRIPTION
This PR disables caching of job files.

- Job files are no longer cached. If you reload after changes are made to a file, those changes will be reflected in the browser.
- A refresh button is added to the job report page.
- A refresh button is added to the jobs list page.