### PR TITLE
update patch for flask_jwt_extended

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,16 +6,17 @@ dependencies:
   - nodejs
   - pip
   - pip:
+    - email-validator
     - flask-authorize
-    - flask-jwt-extended==4.0.2
-    - email_validator
+    - flask-jwt-extended>=4.1.0
     - configargparse
     - connexion[swagger-ui]
     - fasteners
     - flask
-    - flask-bootstrap4
+    - flask_bootstrap
     - flask_cors
     - flask_debugtoolbar
+    - flask_login
     - flask_mail
     - flask_marshmallow
     - flask_moment
@@ -26,10 +27,15 @@ dependencies:
     - python_dateutil
     - requests
     - selenium
-    - sqlalchemy<1.4
+    - sqlalchemy
     - wtforms
+    - flask-authorize
     # For testing:
     - pytest
     - pytest-selenium
     - pytest-flask
     - pytest-cov
+    # For development
+    - black
+    - flake8
+    - twine

--- a/seamm-dashboard.yml
+++ b/seamm-dashboard.yml
@@ -9,7 +9,7 @@ dependencies:
   - pip:
     - email-validator
     - flask-authorize
-    - flask-jwt-extended==4.0.2
+    - flask-jwt-extended>=4.1.0
     - configargparse
     - connexion[swagger-ui]
     - fasteners
@@ -28,8 +28,9 @@ dependencies:
     - python_dateutil
     - requests
     - selenium
-    - sqlalchemy<1.4
+    - sqlalchemy
     - wtforms
+    - flask-authorize
     # For testing:
     - pytest
     - pytest-selenium

--- a/seamm_dashboard/jwt_patch.py
+++ b/seamm_dashboard/jwt_patch.py
@@ -22,25 +22,21 @@ from flask import current_app
 import flask_jwt_extended
 
 
-def _decode_jwt_from_cookies(request_type):
-    if request_type == "access":
-        cookie_key = config.access_cookie_name
-        csrf_header_key = config.access_csrf_header_name
-        csrf_field_key = config.access_csrf_field_name
-    else:
+def _decode_jwt_from_cookies(refresh):
+    if refresh:
         cookie_key = config.refresh_cookie_name
         csrf_header_key = config.refresh_csrf_header_name
         csrf_field_key = config.refresh_csrf_field_name
+    else:
+        cookie_key = config.access_cookie_name
+        csrf_header_key = config.access_csrf_header_name
+        csrf_field_key = config.access_csrf_field_name
 
     encoded_token = request.cookies.get(cookie_key)
     if not encoded_token:
         raise NoAuthorizationError('Missing cookie "{}"'.format(cookie_key))
 
-    if (
-        config.csrf_protect
-        and request.method in config.csrf_request_methods
-        and current_app.config["JWT_CSRF_ACCESS_PATH"] in request.url
-    ):
+    if config.csrf_protect and request.method in config.csrf_request_methods and current_app.config["JWT_CSRF_ACCESS_PATH"] in request.url:
         csrf_value = request.headers.get(csrf_header_key, None)
         if not csrf_value and config.csrf_check_form:
             csrf_value = request.form.get(csrf_field_key, None)


### PR DESCRIPTION
This updates a patched function in `flask_jwt_extended` to be compatible with package version 4.1.0. Package is pinned to be greater than or equal to this number in environment yaml files.