### PR TITLE
Switch flask-sqlalchemy to sqlalchemy

### DIFF
--- a/seamm_dashboard/__init__.py
+++ b/seamm_dashboard/__init__.py
@@ -224,12 +224,13 @@ def create_app(config_name=None):
         from .models.import_jobs import import_jobs
 
         t0 = time.perf_counter()
-        with app.app_context():
-            n_projects, n_added_projects, n_jobs, n_added_jobs = import_jobs(
-                os.path.join(options.datastore, "projects")
-            )
+        n_projects, n_added_projects, n_jobs, n_added_jobs = import_jobs(
+            os.path.join(options.datastore, "projects"),
+            app.config["SQLALCHEMY_DATABASE_URI"],
+            app.config["AUTHORIZE_DEFAULT_PERMISSIONS"],
+        )
 
-            db_session.commit()
+        db_session.commit()
 
         t1 = time.perf_counter()
         logger.info(

--- a/seamm_dashboard/__init__.py
+++ b/seamm_dashboard/__init__.py
@@ -8,8 +8,6 @@ import configargparse
 # from flask_admin import Admin
 from flask_debugtoolbar import DebugToolbarExtension
 from flask_bootstrap import Bootstrap
-from flask_cors import CORS
-from flask_mail import Mail
 from flask_moment import Moment
 from flask_marshmallow import Marshmallow
 
@@ -56,10 +54,6 @@ if "debug" in options:
         )
     os.environ["FLASK_DEBUG"] = options.debug
 
-# continue the setup
-mail = Mail()
-cors = CORS()
-
 bootstrap = Bootstrap()
 
 jwt = flask_jwt_extended.JWTManager()
@@ -69,7 +63,6 @@ moment = Moment()
 toolbar = DebugToolbarExtension()
 
 ma = Marshmallow()
-
 
 @jwt.user_lookup_loader
 def user_loader_callback(jwt_header, jwt_payload):
@@ -149,6 +142,7 @@ def create_app(config_name=None):
     Base.metadata.create_all(engine)
     Base.query = db_session.query_property()
 
+    # Bind a session to the app
     app.db = db_session
 
     from .routes.auth import auth as auth_blueprint
@@ -170,8 +164,6 @@ def create_app(config_name=None):
     app.register_error_handler(404, errors.not_found)
 
     # init
-    mail.init_app(app)
-    cors.init_app(app)
     bootstrap.init_app(app)
     authorize.init_app(app)
     jwt.init_app(app)

--- a/seamm_dashboard/config.py
+++ b/seamm_dashboard/config.py
@@ -41,7 +41,7 @@ class DevelopmentConfig(BaseConfig):
     WORDPRESS_DOMAIN = "http://localhost:8888"
     API_DOMAIN = "http://localhost:5000"
     SQLALCHEMY_DATABASE_URI = "sqlite:///" + os.path.join(
-        _basedir, "data", "projects", "molssi_jobstore.db"
+        _basedir, "..", "data", "seamm.db"
     )
 
 

--- a/seamm_dashboard/models/__init__.py
+++ b/seamm_dashboard/models/__init__.py
@@ -1,4 +1,5 @@
 from .models import (  # noqa: F401
+    Base,
     Job,
     Flowchart,
     Project,

--- a/seamm_dashboard/results_dashboard.py
+++ b/seamm_dashboard/results_dashboard.py
@@ -5,7 +5,7 @@ from seamm_dashboard import create_app
 def run():
     app = create_app()
     # app.run(debug=True, use_reloader=True)
-    app.run(debug=False, use_reloader=False)
+    app.run(debug=True, use_reloader=True)
 
 
 if __name__ == "__main__":

--- a/seamm_dashboard/routes/api/users.py
+++ b/seamm_dashboard/routes/api/users.py
@@ -3,10 +3,10 @@ API calls for users (creating, logging in, logging out)
 
 """
 
-from flask import Response
+from flask import Response, current_app
 from flask_jwt_extended import jwt_required
 
-from seamm_dashboard import db, authorize
+from seamm_dashboard import authorize
 from seamm_dashboard.models import (
     User,
     UserSchema,
@@ -117,8 +117,8 @@ def add_user(body):
     if isinstance(get_data, Response):
         return get_data
 
-    db.session.add(get_data)
-    db.session.commit()
+    current_app.db.add(get_data)
+    current_app.db.commit()
 
     return get_data.id, 201
 

--- a/seamm_dashboard/routes/auth/views.py
+++ b/seamm_dashboard/routes/auth/views.py
@@ -1,6 +1,14 @@
 import logging
 
-from flask import render_template, flash, make_response, request, redirect, url_for
+from flask import (
+    render_template,
+    flash,
+    make_response,
+    request,
+    redirect,
+    url_for,
+    current_app,
+)
 
 from flask_jwt_extended import (
     set_access_cookies,
@@ -13,7 +21,7 @@ from flask_jwt_extended import (
 
 from .forms import LoginForm, ConfirmLogin, UpdateAccountInfoForm
 
-from seamm_dashboard import authorize, db
+from seamm_dashboard import authorize
 from seamm_dashboard.models import User, UserSchema, UserProjectAssociation
 
 from . import auth
@@ -123,8 +131,8 @@ def my_account():
             if form.password:
                 current_user.password = form.password.data
 
-            db.session.add(current_user)
-            db.session.commit()
+            current_app.db.add(current_user)
+            current_app.db.commit()
 
             flash("Your account has been updated.")
 

--- a/seamm_dashboard/routes/jobs/views.py
+++ b/seamm_dashboard/routes/jobs/views.py
@@ -1,8 +1,8 @@
-from flask import request, render_template, flash, redirect, url_for
+from flask import request, render_template, flash, redirect, url_for, current_app
 
 from flask_jwt_extended import jwt_required, get_current_user
 
-from seamm_dashboard import db, authorize
+from seamm_dashboard import authorize
 
 from . import jobs
 
@@ -63,7 +63,7 @@ def edit_job(job_id):
     if form.validate_on_submit():
         job.title = form.name.data
         job.description = form.notes.data
-        db.session.commit()
+        current_app.db.commit()
         flash("Job updated successfully.", "successs")
 
         return redirect(job_url)

--- a/seamm_dashboard/routes/projects/views.py
+++ b/seamm_dashboard/routes/projects/views.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from flask import render_template, url_for, request, flash, redirect
+from flask import render_template, url_for, request, flash, redirect, current_app
 from flask_jwt_extended import jwt_required, get_current_user
 
 from wtforms import BooleanField
@@ -10,7 +10,7 @@ from .forms import EditProject, ManageProjectAccessForm
 
 from seamm_dashboard.models import Project, User, UserProjectAssociation
 
-from seamm_dashboard import authorize, db
+from seamm_dashboard import authorize
 
 
 def _bind_users_to_form(form, current_user, project_id):
@@ -93,7 +93,7 @@ def edit_project(project_id):
     if form.validate_on_submit():
         project.name = form.name.data
         project.description = form.notes.data
-        db.session.commit()
+        current_app.db.commit()
         flash("Project updated successfully.", "successs")
 
         return redirect(project_url)
@@ -177,8 +177,8 @@ def manage_project(project_id):
                 else:
                     assoc.permissions = permissions
 
-                db.session.add(assoc)
-                db.session.commit()
+                current_app.db.add(assoc)
+                current_app.db.commit()
 
             flash(f"Permissions for {project.name} successfully updated.")
             return redirect(project_url)

--- a/seamm_dashboard/tests/conftest.py
+++ b/seamm_dashboard/tests/conftest.py
@@ -4,7 +4,9 @@ import os
 import shutil
 from dateutil import parser
 
-from seamm_dashboard import create_app, db
+from flask import current_app
+
+from seamm_dashboard import create_app
 from seamm_dashboard.models.util import process_flowchart
 from seamm_dashboard.models import (
     Job,
@@ -139,22 +141,20 @@ def app(project_directory):
     )
     a.job = job1
     visitor.special_jobs.append(a)
-    db.session.add(a)
-    db.session.add(visitor)
-    # assert False, job1.special_users.all()
-    # db.session.commit()
+    current_app.db.add(a)
+    current_app.db.add(visitor)
 
     flowchart = Flowchart(**flowchart_data)
-    db.session.add(test_user)
-    db.session.add(admin_role)
-    db.session.add(manager_role)
-    db.session.add(test_admin)
-    db.session.add(project)
-    db.session.add(job1)
-    db.session.add(job2)
-    db.session.add(job3)
-    db.session.add(flowchart)
-    db.session.commit()
+    current_app.db.add(test_user)
+    current_app.db.add(admin_role)
+    current_app.db.add(manager_role)
+    current_app.db.add(test_admin)
+    current_app.db.add(project)
+    current_app.db.add(job1)
+    current_app.db.add(job2)
+    current_app.db.add(job3)
+    current_app.db.add(flowchart)
+    current_app.db.commit()
 
     yield flask_app
 


### PR DESCRIPTION
This PR removes flask-sqlalchemy from the models. This removes the necessity of having a flask app bound to a port in order to use the sqlalchemy models. 

This PR also removes the flask context from the utility functions which import jobs. We may now be able to just use the `import_job` function in `utils` to import jobs. Note that when you use this function you must pass a database location *and* default permissions. The `flask-authorize` app we use for authorization attempts to set permissions based on the current flask app if you do not specify permissions when adding an item to the DB, causing a failure outside of the application context. If you specify permissions, this does not occur. I am passing the default permissions to the `import_jobs` function on app initialization but these could be set to anything with the way the function is currently written.

API tests are passing locally.

Still to do -

- [ ] Some parts of models still depends on an application context. The application context typically has a bound database session. Need to figure out how to access session bound to base object instead.
- [ ] I have fixed the other tests which are failing on Linux and it appears we are still having trouble with the application context on the front end.