### PR TITLE
prevent deletion of some files associated with jstree

### DIFF
--- a/seamm_dashboard/jwt_patch.py
+++ b/seamm_dashboard/jwt_patch.py
@@ -36,7 +36,11 @@ def _decode_jwt_from_cookies(refresh):
     if not encoded_token:
         raise NoAuthorizationError('Missing cookie "{}"'.format(cookie_key))
 
-    if config.csrf_protect and request.method in config.csrf_request_methods and current_app.config["JWT_CSRF_ACCESS_PATH"] in request.url:
+    if (
+        config.csrf_protect
+        and request.method in config.csrf_request_methods
+        and current_app.config["JWT_CSRF_ACCESS_PATH"] in request.url
+    ):
         csrf_value = request.headers.get(csrf_header_key, None)
         if not csrf_value and config.csrf_check_form:
             csrf_value = request.form.get(csrf_field_key, None)

--- a/seamm_dashboard/static/only_needed_files.py
+++ b/seamm_dashboard/static/only_needed_files.py
@@ -9,6 +9,15 @@ import os
 import shutil
 
 if __name__ == "__main__":
+
+    # manual addition of files which are needed but not picked up by the regex below.
+    needed_but_unlisted = [
+        os.path.join(
+            "node_modules", "jstree", "dist", "themes", "default", "throbber.gif"
+        ),
+        os.path.join("node_modules", "jstree", "dist", "themes", "default", "32px.png"),
+    ]
+
     full_path = os.path.abspath(os.path.join("..", "templates/"))
 
     bashCommand = f"grep -r {full_path} -e node_modules"
@@ -26,6 +35,10 @@ if __name__ == "__main__":
     matches = pattern.findall(data)
 
     matches = list(set(matches))
+
+    matches.extend(needed_but_unlisted)
+
+    # assert False, matches
 
     tree = os.walk("node_modules")
 


### PR DESCRIPTION
This PR prevents deletion of some necessary files associated with the jstree package which are not found with the current method of cleaning up unneeded files.