### PR TITLE
change permissions checks to be on projects rather than only on jobs

### DIFF
--- a/seamm_dashboard/models/__init__.py
+++ b/seamm_dashboard/models/__init__.py
@@ -5,11 +5,8 @@ from .models import (  # noqa: F401
     User,
     Group,
     Role,
-    UserJobAssociation,
-    GroupJobAssociation,
     UserProjectAssociation,
     GroupProjectAssociation,
-    GroupFlowchartAssociation,
 )
 from .models import (  # noqa: F401
     JobSchema,

--- a/seamm_dashboard/models/models.py
+++ b/seamm_dashboard/models/models.py
@@ -22,128 +22,15 @@ from seamm_dashboard import db, jwt
 #############################
 
 # Authentication Mapping Tables for Access Control
-UserJobMixin = generate_association_table("User", "Job")
-UserFlowchartMixin = generate_association_table("User", "Flowchart")
 UserProjectMixin = generate_association_table("User", "Project")
-GroupJobMixin = generate_association_table("Group", "Job")
 GroupProjectMixin = generate_association_table("Group", "Project")
-GroupFlowchartMixin = generate_association_table("Group", "Flowchart")
-
-
-class UserJobAssociation(db.Model, UserJobMixin):
-    pass
-
-
-class UserFlowchartAssociation(db.Model, UserFlowchartMixin):
-    pass
 
 
 class UserProjectAssociation(db.Model, UserProjectMixin):
-    def __setattr__(self, name, value):
-        """
-        Change behavior of set attribute so that when a user gets permissions for a
-        project, they get updated permissions for all jobs and flowcharts within the
-        project.
-        """
-        from seamm_dashboard import db
-
-        if name == "permissions":
-            # See if there is an asociation between the group and project
-            project = Project.query.filter_by(id=self.resource_id).one()
-
-            if project.jobs:
-                for job in project.jobs:
-                    assoc = UserJobAssociation.query.filter_by(
-                        entity_id=self.entity_id, resource_id=job.id
-                    ).one_or_none()
-
-                    if assoc:
-                        assoc.permissions = value
-                    else:
-                        assoc = UserJobAssociation(
-                            entity_id=self.entity_id,
-                            resource_id=job.id,
-                            permissions=value,
-                        )
-
-                    db.session.add(assoc)
-                    db.session.commit()
-
-            if project.flowcharts:
-                for flowchart in project.flowcharts:
-                    assoc = UserFlowchartAssociation.query.filter_by(
-                        entity_id=self.entity_id, resource_id=flowchart.id
-                    ).one_or_none()
-                    if assoc:
-                        assoc.permissions = value
-                    else:
-                        assoc = UserFlowchartAssociation(
-                            entity_id=self.entity_id,
-                            resource_id=flowchart.id,
-                            permissions=value,
-                        )
-
-                    db.session.add(assoc)
-                    db.session.commit()
-
-        super().__setattr__(name, value)
-
-
-class GroupJobAssociation(db.Model, GroupJobMixin):
     pass
 
 
 class GroupProjectAssociation(db.Model, GroupProjectMixin):
-    def __setattr__(self, name, value):
-        """
-        Change behavior of set attribute so that when a group gets permissions for a
-        project, they get updated permissions for all jobs and flowcharts within the
-        project.
-        """
-        from seamm_dashboard import db
-
-        if name == "permissions":
-            # See if there is an asociation between the group and project
-            project = Project.query.filter_by(id=self.resource_id).one()
-
-            if project.jobs:
-                for job in project.jobs:
-                    assoc = GroupJobAssociation.query.filter_by(
-                        entity_id=self.entity_id, resource_id=job.id
-                    ).one_or_none()
-                    if assoc:
-                        assoc.permissions = value
-                    else:
-                        assoc = GroupJobAssociation(
-                            entity_id=self.entity_id,
-                            resource_id=job.id,
-                            permissions=value,
-                        )
-
-                    db.session.add(assoc)
-                    db.session.commit()
-
-            if project.flowcharts:
-                for flowchart in project.flowcharts:
-                    assoc = GroupFlowchartAssociation.query.filter_by(
-                        entity_id=self.entity_id, resource_id=flowchart.id
-                    ).one_or_none()
-                    if assoc:
-                        assoc.permissions = value
-                    else:
-                        assoc = GroupFlowchartAssociation(
-                            entity_id=self.entity_id,
-                            resource_id=flowchart.id,
-                            permissions=value,
-                        )
-
-                    db.session.add(assoc)
-                    db.session.commit()
-
-        super().__setattr__(name, value)
-
-
-class GroupFlowchartAssociation(db.Model, GroupFlowchartMixin):
     pass
 
 

--- a/seamm_dashboard/tests/conftest.py
+++ b/seamm_dashboard/tests/conftest.py
@@ -12,7 +12,7 @@ from seamm_dashboard.models import (
     Project,
     User,
     Role,
-    UserJobAssociation,
+    UserProjectAssociation,
 )
 from selenium import webdriver
 
@@ -65,11 +65,16 @@ def app(project_directory):
     app_context.push()
 
     # Create a sample project
-    test_project = {"name": "MyProject", "path": test_project_path, "owner_id": 3}
+    test_project = {
+        "name": "MyProject",
+        "path": test_project_path,
+        "owner_id": 3,
+        "id": 100,
+    }
 
     project = Project(**test_project)
 
-    # Create some sample role
+    # Create some sample roles
     admin_role = Role.query.filter_by(name="admin").one_or_none()
     manager_role = Role.query.filter_by(name="group manager").one_or_none()
     user_role = Role.query.filter_by(name="user").one_or_none()
@@ -129,20 +134,17 @@ def app(project_directory):
 
     # Add job3 and readable for world.
     job3 = Job(**job3_data)
-
     job3.permissions = {"other": ["read"]}
 
-    # Add visitor and give read access to a job
+    # Add visitor and give read access to a project
     visitor = User(username="visitor", password="visitor", id=10)
-    a = UserJobAssociation(
-        permissions=["read"], resource_id=job2.id, entity_id=visitor.id
+    a = UserProjectAssociation(
+        permissions=["read"], resource_id=project.id, entity_id=visitor.id
     )
     a.job = job1
-    visitor.special_jobs.append(a)
+    visitor.special_projects.append(a)
     db.session.add(a)
     db.session.add(visitor)
-    # assert False, job1.special_users.all()
-    # db.session.commit()
 
     flowchart = Flowchart(**flowchart_data)
     db.session.add(test_user)

--- a/seamm_dashboard/tests/test_api_authenticated.py
+++ b/seamm_dashboard/tests/test_api_authenticated.py
@@ -36,7 +36,7 @@ def test_get_jobs(createdSince, createdBefore, limit, expected_number, auth_clie
     response = auth_client.get(query_string)
     jobs_received = response.json
 
-    assert len(jobs_received) == expected_number
+    assert len(jobs_received) == expected_number, jobs_received[0]["id"]
 
 
 def test_get_job_by_id(auth_client):
@@ -149,7 +149,7 @@ def test_get_project(auth_client):
 
     auth_client = auth_client[0]
 
-    response = auth_client.get("api/projects/2")
+    response = auth_client.get("api/projects/100")
 
     assert response.status_code == 200
 
@@ -159,7 +159,7 @@ def test_get_project_jobs(auth_client):
 
     auth_client = auth_client[0]
 
-    response = auth_client.get("api/projects/2/jobs")
+    response = auth_client.get("api/projects/100/jobs")
 
     assert response.status_code == 200
 
@@ -169,6 +169,6 @@ def test_get_project_jobs_404(auth_client):
 
     auth_client = auth_client[0]
 
-    response = auth_client.get("api/projects/100/jobs")
+    response = auth_client.get("api/projects/1000/jobs")
 
     assert response.status_code == 404

--- a/seamm_dashboard/tests/test_api_visitor.py
+++ b/seamm_dashboard/tests/test_api_visitor.py
@@ -10,5 +10,5 @@ def test_get_jobs(visitor_client):
     response = auth_client.get("api/jobs")
 
     # Two because there is one public job, and one job they have been added to,
-    assert len(response.json) == 2, len(response.json)
+    assert len(response.json) == 3, len(response.json)
     assert response.status_code == 200


### PR DESCRIPTION
This addresses the hierarchical permissions problem we discussed this morning. 

**Problem statement:** 
Jobs and flowcharts can belong to multiple projects. In the previous/current model, this was a problem because permissions for jobs was stored directly on the job, and a job could hold only one set of permissions. This could potentially lead to permissions clashes between jobs.

**Solution:**
In this solution, we check the job permissions first (owner, group, world). If permission to access the job or flowchart is not found under these, permissions on project(s) containing the job or flowchart are checked to determine if the user has access.

This is done in the API endpoints for accessing jobs or flowcharts rather than inside of the code in charge of permissions. I had avoided this in the past for fear of worse performance. However, it might be unlikely that users will have enough jobs to notice poor performance.

This closes #83 

Also note that in the future if we did want to allow permissions by job or flowchart, we could still add those. It would require addition of more tables to the DB.