### PR TITLE
make job report refresh update status

### DIFF
--- a/seamm_dashboard/static/js/job_report.js
+++ b/seamm_dashboard/static/js/job_report.js
@@ -376,6 +376,11 @@ $(document).ready(function() {
             $('#js-tree').jstree(true).settings.core.data = newData;
             $('#js-tree').jstree("refresh")
             document.getElementById("js-tree").classList.toggle("hidden")
+
+            // Update the job data and status.
+            jobData = getJobData(jobID);
+            $("#job-status").html(jobData.status);
+            $("#job-title").html(jobData.title);
         }
     )
 

--- a/seamm_dashboard/templates/jobs/job_report.html
+++ b/seamm_dashboard/templates/jobs/job_report.html
@@ -8,7 +8,7 @@
 <div class="animated fadeIn vh-100 mh-100 hidden" id="view">
     <div class="row">
       <div class="col-sm-3">
-        <div class="h4 mt-3 row" id="root-folder"></div>
+        <div class="h4 mt-3 row"><span id="root-folder"></span><span><button type="button" id="refresh-file-list" class="btn btn btn-outline-primary float-right mb-3 ml-5" title="Refresh Job Info" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button></span></div>
         <div class="row"><strong>Title: </strong> <span id="job-title" class="ml-2">{{ job.title }}</span></div>
         <div class="row"><strong>Status: </strong><span id="job-status" class="ml-2"></span></div>
         <div class="row"><strong>{{ own_string }}</strong></div>
@@ -22,7 +22,7 @@
           {% endif %}
 
         </div>
-        <div class='h5 mt-3'>Browse files for job<span><button type="button" id="refresh-file-list" class="btn btn btn-outline-primary float-right mb-3" title="Refresh File List" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button></span></div>
+        <div class='h5 mt-3'>Browse files for job</div>
         <div class="input-group">
           <input type="text" class="form-control" placeholder="Search Files" id="search">
           <span class="input-group-btn">


### PR DESCRIPTION
This PR modifies the refresh button on the job report page so that job status and title are also updated when the file list is refreshed. The button is moved to be next to the directory name - see attached screenshot
![Screen Shot 2022-01-03 at 11 56 35 AM](https://user-images.githubusercontent.com/18010556/147964155-23fb5f83-9ef3-4b1f-9ff2-5788abfbea4d.png)
![Screen Shot 2022-01-03 at 12 00 44 PM](https://user-images.githubusercontent.com/18010556/147964160-049ccbf1-00b1-4467-9e89-d7124f81b6d0.png)
s