### PR TITLE
Make sure the Jobs/projects directory is created before importing jobs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ typing: ## check typing
 
 test: ## run tests quickly with the default Python
 	devtools/scripts/install_chromedriver.py
-	pytest
+	pytest -rxX
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/seamm_dashboard/__init__.py
+++ b/seamm_dashboard/__init__.py
@@ -36,7 +36,8 @@ del get_versions, versions
 # Ensure that the projects directory exists.
 datastore_path = Path(options["datastore"]).expanduser().resolve()
 datastore = str(datastore_path)
-datastore_path.mkdir(parents=True, exist_ok=True)
+projects_path = datastore_path / "projects"
+projects_path.mkdir(parents=True, exist_ok=True)
 
 # Setup the logging, now that we know where the datastore is
 setup_logging(datastore, options)
@@ -194,11 +195,8 @@ def create_app(config_name=None):
             from seamm_datastore.database.models import User
 
             flask_authorize.plugin.CURRENT_USER = User.query.filter_by(id=2).one
-            temp_path = os.path.join(
-                os.path.expanduser(options["datastore"]), "projects"
-            )
             logger.warning("Importing any jobs into the database.")
-            import_datastore(db.session, temp_path)
+            import_datastore(db.session, str(projects_path))
 
             flask_authorize.plugin.CURRENT_USER = flask_jwt_extended.get_current_user
 

--- a/seamm_dashboard/tests/test_views.py
+++ b/seamm_dashboard/tests/test_views.py
@@ -227,7 +227,7 @@ class TestLiveServer:
         job_link.click()
 
         # Give time to load
-        time.sleep(0.25)
+        time.sleep(1.25)
 
         # When clicked, file text should be displayed in the div.
         displayed_text = chrome_driver.find_element_by_id("file-content").text


### PR DESCRIPTION
fixes #95 A crash happens on initial installation because ~/SEAMM/Jobs/projects does not exist, and importing the jobs in the Datastore does not gracefully handle not having the directory. There was a purported fix in the code but it ignored the 'projects' subdirectory. This corrects that and then uses that directory when importing jobs, rather than duplicate the construction of the path.