### PR TITLE
Allowing setting port on command line 

### DIFF
--- a/seamm_dashboard/results_dashboard.py
+++ b/seamm_dashboard/results_dashboard.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from seamm_dashboard import create_app, options
 
-print(options)
 
 def run():
     app = create_app()

--- a/seamm_dashboard/results_dashboard.py
+++ b/seamm_dashboard/results_dashboard.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
-from seamm_dashboard import create_app
+from seamm_dashboard import create_app, options
 
+print(options)
 
 def run():
     app = create_app()
     # app.run(debug=True, use_reloader=True)
-    app.run(debug=False, use_reloader=False)
+    app.run(debug=False, use_reloader=False, port=options["port"])
 
 
 if __name__ == "__main__":

--- a/seamm_dashboard/routes/api/jobs.py
+++ b/seamm_dashboard/routes/api/jobs.py
@@ -144,6 +144,10 @@ def add_job(body):
     project_names = [body["project"]]
     title = body["title"]
     description = body["description"]
+    if "parameters" in body:
+        parameters = body["parameters"]
+    else:
+        parameters = {}
 
     # Get the unique ID for the job...
     if options["job_id_file"] is None:
@@ -187,6 +191,7 @@ def add_job(body):
         project_names=project_names,
         title=title,
         description=description,
+        parameters=parameters,
     )
 
     return {"id": job_id}, 201, {"location": format("/jobs/{}".format(job_id))}

--- a/seamm_dashboard/setup_argparsing.py
+++ b/seamm_dashboard/setup_argparsing.py
@@ -15,6 +15,15 @@ parser.add_argument_group(
 
 parser.add_argument(
     "SEAMM",
+    "--port",
+    group="dashboard options",
+    default=5000,
+    type=int,
+    help="the port to use",
+)
+
+parser.add_argument(
+    "SEAMM",
     "--initialize",
     group="dashboard options",
     action="store_true",
@@ -666,7 +675,7 @@ parser.add_argument(
     "--mail-port",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=25"),
+    help="default=25",
 )
 
 parser.add_argument(
@@ -674,7 +683,7 @@ parser.add_argument(
     "--mail-use-TLS",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=False"),
+    help="default=False",
 )
 
 parser.add_argument(
@@ -682,7 +691,7 @@ parser.add_argument(
     "--mail-use-SSL",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=False"),
+    help="default=False",
 )
 
 parser.add_argument(
@@ -690,7 +699,7 @@ parser.add_argument(
     "--mail-debug",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("", "default=app.debug"),
+    help="default=app.debug",
 )
 
 parser.add_argument(
@@ -698,7 +707,7 @@ parser.add_argument(
     "--mail-username",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=None"),
+    help="default=None",
 )
 
 parser.add_argument(
@@ -706,7 +715,7 @@ parser.add_argument(
     "--mail-password",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=None"),
+    help="default=None",
 )
 
 parser.add_argument(
@@ -714,7 +723,7 @@ parser.add_argument(
     "--mail-default-sender",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=None"),
+    help="default=None",
 )
 
 parser.add_argument(
@@ -722,7 +731,7 @@ parser.add_argument(
     "--mail-max-emails",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=None"),
+    help="default=None",
 )
 
 parser.add_argument(
@@ -730,7 +739,7 @@ parser.add_argument(
     "--mail-suppress-send",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=app.testing"),
+    help="default=app.testing",
 )
 
 parser.add_argument(
@@ -738,7 +747,7 @@ parser.add_argument(
     "--mail-ascii-attachments",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=("" "default=False"),
+    help="default=False",
 )
 
 parser.add_argument(
@@ -746,11 +755,11 @@ parser.add_argument(
     "--mail-subject-prefix",
     group="mail options",
     default=argparse.SUPPRESS,
-    help=(""),
+    help="",
 )
 
 parser.add_argument(
-    "SEAMM", "--mail-sender", group="mail options", default=argparse.SUPPRESS, help=("")
+    "SEAMM", "--mail-sender", group="mail options", default=argparse.SUPPRESS, help=""
 )
 
 # And handle the command-line arguments and ini file options.

--- a/seamm_dashboard/tests/test_views.py
+++ b/seamm_dashboard/tests/test_views.py
@@ -216,9 +216,11 @@ class TestLiveServer:
 
         # Initially, there should be nothing in the text box.
 
-        initial_displayed_text = WebDriverWait(chrome_driver, 20).until(
-            EC.presence_of_element_located((By.ID, "file-content"))
-        ).text
+        initial_displayed_text = (
+            WebDriverWait(chrome_driver, 20)
+            .until(EC.presence_of_element_located((By.ID, "file-content")))
+            .text
+        )
 
         # Get a link for a file and click on it.
         job_link = WebDriverWait(chrome_driver, 20).until(
@@ -237,7 +239,9 @@ class TestLiveServer:
         # Splitting on whitespace and rejoining let's us compare the file
         # contents without worrying about how whitespace is handled.
         assert initial_displayed_text == "", "initial displayed text error"
-        assert " ".join(displayed_text_list) == " ".join(file_contents_split), "displayed text error"
+        assert " ".join(displayed_text_list) == " ".join(
+            file_contents_split
+        ), "displayed text error"
 
     def test_job_report_file_content_refresh(
         self, app, chrome_driver, project_directory
@@ -262,9 +266,11 @@ class TestLiveServer:
         chrome_driver.get(f"{self.base_url}#jobs/1")
 
         # Initially, there should be nothing in the text box.
-        initial_displayed_text = WebDriverWait(chrome_driver, 20).until(
-            EC.presence_of_element_located((By.ID, "file-content"))
-        ).text
+        initial_displayed_text = (
+            WebDriverWait(chrome_driver, 20)
+            .until(EC.presence_of_element_located((By.ID, "file-content")))
+            .text
+        )
 
         # Get a link for a file and click on it.
         job_link = WebDriverWait(chrome_driver, 20).until(


### PR DESCRIPTION
- Setting port on the command-line via an option
- Added to the api to handle the new parameters filed in jobs, which is used to handle essentially command-line parameters.
- Cleaned up the options, which had odd strings that apparently caused crash with `seamm-dashboard --help`.
- Let black reformat test_views -- no change in functionality, just formatting.