### PR TITLE
Improves expired token browser check

### DIFF
--- a/seamm_dashboard/routes/jobs/forms.py
+++ b/seamm_dashboard/routes/jobs/forms.py
@@ -14,8 +14,8 @@ class EditJob(FlaskForm):
             Regexp(
                 "^[A-Za-z][A-Za-z0-9_. ]*$",
                 0,
-                "Job titles must have only letters, numbers, "+
-                "dots, spaces, or underscores",
+                "Job titles must have only letters, numbers, "
+                + "dots, spaces, or underscores",
             ),
         ],
     )

--- a/seamm_dashboard/routes/projects/forms.py
+++ b/seamm_dashboard/routes/projects/forms.py
@@ -13,8 +13,8 @@ class EditProject(FlaskForm):
             Regexp(
                 "^[A-Za-z][A-Za-z0-9_. ]*$",
                 0,
-                "Projects must have only letters, numbers, " + 
-                "dots, spaces, or underscores",
+                "Projects must have only letters, numbers, "
+                + "dots, spaces, or underscores",
             ),
         ],
     )
@@ -31,8 +31,8 @@ class AddProject(FlaskForm):
             Regexp(
                 "^[A-Za-z][A-Za-z0-9_. ]*$",
                 0,
-                "Projects must have only letters, numbers, " + 
-                "dots, spaces, or underscores",
+                "Projects must have only letters, numbers, "
+                + "dots, spaces, or underscores",
             ),
         ],
     )


### PR DESCRIPTION
The app must have different behavior when an expired token is encountered depending on if the user is the the browser or using another interface like a command line utility. In the case of the browser, the desired behavior is that the user is logged out and redirected to the main page. If a command line utility is used, the user should be informed that their token has expired.

This PR improves the check for user agent and adds a message in case the user does see the json in a browser.