### PR TITLE
Add dashboard name option and display of name

### DIFF
--- a/seamm_dashboard/routes/api/jobs.py
+++ b/seamm_dashboard/routes/api/jobs.py
@@ -44,6 +44,7 @@ file_icons = {
     "pdb": "fas fa-cubes",
     "mmcif": "fas fa-cubes",
     "cif": "fas fa-cubes",
+    "cube": "fas fa-cube"
 }
 
 

--- a/seamm_dashboard/routes/api/status.py
+++ b/seamm_dashboard/routes/api/status.py
@@ -3,6 +3,7 @@ API calls for the status
 """
 import logging
 
+from seamm_dashboard.setup_argparsing import options
 from seamm_datastore.database.models import Project, Job, Flowchart
 from seamm_datastore.database.schema import RoleSchema
 
@@ -58,6 +59,7 @@ def status():
 
     # Build return json
     status = {
+        "dashboard": options["dashboard_name"],
         "status": "running",
         "user id": user_id,
         "username": username,

--- a/seamm_dashboard/setup_argparsing.py
+++ b/seamm_dashboard/setup_argparsing.py
@@ -1,6 +1,8 @@
 import argparse
 from pathlib import Path
 import sys
+from socket import gethostname
+
 
 import seamm_util
 
@@ -35,6 +37,14 @@ parser.add_argument(
     group="dashboard options",
     action="store_true",
     help="do not check that jobs are in the database",
+)
+
+parser.add_argument(
+    "SEAMM",
+    "--dashboard-name",
+    group="dashboard options",
+    default=gethostname(),
+    help="The name of the dashboard.",
 )
 
 parser.add_argument(

--- a/seamm_dashboard/static/js/job_report.js
+++ b/seamm_dashboard/static/js/job_report.js
@@ -147,15 +147,21 @@ function loadStructure(URL) {
         let fileExtension = URL.split(".");
         fileExtension = fileExtension[fileExtension.length - 1]
         let stage = new NGL.Stage("structure", {backgroundColor: "white"} );
-
         if (representation == "default") {
-            stage.loadFile(URL, {defaultRepresentation: true, ext: fileExtension });
+            stage.loadFile(URL, {defaultRepresentation: true, ext: fileExtension }).then(function (component) {
+                // add unit cell if there is one
+                component.addRepresentation("unitcell")
+                // provide a "good" view of the structure
+                component.autoView();
+                });;
         }
 
         else {
             stage.loadFile(URL, {ext: fileExtension }).then(function (component) {
             // add specified representation to the structure component
             component.addRepresentation(representation);
+            // add unit cell if there is one
+            component.addRepresentation("unitcell")
             // provide a "good" view of the structure
             component.autoView();
             });

--- a/seamm_dashboard/static/js/setup.js
+++ b/seamm_dashboard/static/js/setup.js
@@ -1,9 +1,11 @@
+// Set up the main window - load in appropriate menus for login, user, dashboard name.
+
 // Prevent caching on ajax calls.
 $.ajaxSetup ({
     cache: false
     });
 
-    // Get username and stuff
+    // Get username and dashboard name and stuff
     $.ajax({
     url: `${location.origin}/api/status`,
     dataType: 'json',
@@ -39,7 +41,7 @@ $.ajaxSetup ({
             }
 
             if (data.roles.includes("group manager")) {
-              loginString = loginString.concat(`<h6 class="dropdown-header">Admin Actions</h6>
+              loginString = loginString.concat(`<h6 class="dropdown-header">Manager Actions</h6>
               <a class="dropdown-item" href="/admin/manage_groups">Manage Groups</a>`)
             }
 
@@ -54,6 +56,7 @@ $.ajaxSetup ({
         }
 
         document.getElementById("login-info").innerHTML = loginString
+        document.getElementById("dashboard-name").innerHTML = `<h2>${data.dashboard}</h2>`
         },
         // error occurs because of expired access token. Remove cookie and reload page
     error: function () {

--- a/seamm_dashboard/static/js/table_api.js
+++ b/seamm_dashboard/static/js/table_api.js
@@ -108,7 +108,12 @@ Do you wish to continue?
                             },
                             data: putData,
                             complete: function(xhr, status) {
-                                location.reload() 
+                                if (xhr.status == 401) {
+                                    alert(`You do not have the necessary permission to ${action} job ${jobID}.`) 
+                                }
+                                else {
+                                    location.reload() 
+                                }
                             }
                         });
                     } else if (action === "delete") {

--- a/seamm_dashboard/templates/index.html
+++ b/seamm_dashboard/templates/index.html
@@ -31,10 +31,11 @@
         <img class="navbar-brand-full" src="{{ url_for('static', filename='images/MolSSI-Logo-xl.jpg') }}"  height="50" alt="MolSSI">
         <img class="navbar-brand-minimized" src="{{ url_for('static', filename='images/molssi-favicon.jpg') }}" width="30" height="30" alt="MolSSI Logo">
       </a>
-      <ul class="navbar-nav">
+      <span id="dashboard-name"><h2></h2></span>
+      <!--<ul class="navbar-nav">
         <li class="nav-item">
         </li>
-    </ul>
+    </ul>-->
       <ul class="navbar-nav" id="login-info">
       </ul>
     </header>

--- a/seamm_dashboard/templates/projects/project_access.html
+++ b/seamm_dashboard/templates/projects/project_access.html
@@ -79,13 +79,14 @@
                 </fieldset>
             </div>
         </div>
+        <div>
+            <span class="ml-3">{{ wtf.form_field(form.allow_public, class="form-control") }}</span>
+        </div>
         <div class="mb-5"> 
             {{ wtf.form_field(form.submit, class="btn btn-primary form-control") }}
         </div>
     </form>
 </div>
 </div>
-
-
 {% endblock %}
 

--- a/seamm_dashboard/templates/views/main.html
+++ b/seamm_dashboard/templates/views/main.html
@@ -79,7 +79,10 @@
             <thead>
               <tr>
                 <th>
-                  Job
+                  
+                </th>
+                <th>
+                  Job 
                 </th>
                 <th>
                   Title

--- a/seamm_dashboard/templates/views/main.html
+++ b/seamm_dashboard/templates/views/main.html
@@ -79,10 +79,9 @@
             <thead>
               <tr>
                 <th>
-                  
                 </th>
                 <th>
-                  Job 
+                  Job ID 
                 </th>
                 <th>
                   Title


### PR DESCRIPTION
This PR improves some UI features of SEAMM.

- Adds visualization of unit cell for molecules with unit cell.
- Adds option to make project publicly readable
- Fixes table headers on the front page
- adds support for visualization of cube files.
- adds the ability to set the name of a dashboard using the option `--dashboard-name`. By default, the dashboard name will be set to the (computer) hostname, which is obtained from `socket.gethostname()`.

Display of the dashboard name is added to the `api/status` endpoint and the outer frame of the dashboard graphical interface (see attached screenshot)
![different_name](https://user-images.githubusercontent.com/18010556/187246113-e5a5720d-5289-43c4-ad2f-01be3d6c63b8.png)
