### PR TITLE
add ability to link to files in jobs

### DIFF
--- a/seamm_dashboard/routes/api/jobs.py
+++ b/seamm_dashboard/routes/api/jobs.py
@@ -360,7 +360,7 @@ def get_job_files(id):
 
     js_tree.append(
         {
-            "id": path,
+            "id": "root",
             "parent": "#",
             "text": base_dir,
             "state": {
@@ -384,10 +384,11 @@ def get_job_files(id):
             encoded_path = urllib.parse.quote(os.path.join(root, name), safe="")
             safe_encode = urllib.parse.quote(os.path.join(safe, name), safe="")
 
+            # Add files to tree. File nodes do not have children.
             js_tree.append(
                 {
-                    "id": encoded_path,
-                    "parent": parent,
+                    "id": os.path.join(root, name).replace(job.path, "root"),
+                    "parent": parent.replace(job.path, "root"),
                     "text": name,
                     "a_attr": {
                         "href": f"api/jobs/{id}/files/download?filename={safe_encode}",
@@ -401,11 +402,12 @@ def get_job_files(id):
                 }
             )
 
+        # Add directory nodes to tree.
         for name in sorted(dirs):
             js_tree.append(
                 {
-                    "id": os.path.join(root, name),
-                    "parent": parent,
+                    "id": os.path.join(root, name).replace(job.path, "root"),
+                    "parent": parent.replace(job.path, "root"),
                     "text": name,
                     "icon": file_icons["folder"],
                 }

--- a/seamm_dashboard/routes/jobs/views.py
+++ b/seamm_dashboard/routes/jobs/views.py
@@ -25,8 +25,9 @@ def jobs_list():
 
 @jobs.route("/views/jobs/<id>")
 @jobs.route("/views//jobs/<id>")
+@jobs.route("/views/jobs/<id>?filename=<filename>")
 @jwt_required(optional=True)
-def job_details(id):
+def job_details(id, filename=None):
 
     from seamm_datastore.util import NotAuthorizedError
 

--- a/seamm_dashboard/templates/index.html
+++ b/seamm_dashboard/templates/index.html
@@ -133,6 +133,8 @@
     <script src="{{ url_for('static', filename='node_modules/datatables.net-bs4/js/dataTables.bootstrap4.min.js') }}"></script> 
     <script src="{{ url_for('static', filename='node_modules/datatables.net-buttons/js/dataTables.buttons.min.js') }}"></script>
     <script src="{{ url_for('static', filename='node_modules/datatables.net-select/js/dataTables.select.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='node_modules/ngl/dist/ngl.js') }}"></script>
+
     <!--Page monitor and status-->
     <script src="{{ url_for('static', filename='js/setup.js') }}"></script>
 

--- a/seamm_dashboard/templates/jobs/job_report.html
+++ b/seamm_dashboard/templates/jobs/job_report.html
@@ -8,7 +8,6 @@
 <script src="{{ plotly }}"></script>
 <script src= "{{ url_for('static', filename='js/job_report.js') }}"></script>
 <script src= "{{ url_for('static', filename='js/tooltips.js') }}"></script>
-<script src="{{ url_for('static', filename='node_modules/ngl/dist/ngl.js') }}"></script>
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom_flowchart.css') }}">
 
 <div class="animated fadeIn vh-100 mh-100 hidden" id="view">
@@ -42,6 +41,7 @@
           <div class="card-header btn">
             <span id="file-name">Click Files to view</span>
             <button type="button" id="refresh" class="btn btn-sm btn-outline-primary float-right" title="Refresh File Contents" data-toggle="tooltip" data-placement="top"><i class="fas fa-sync"></i></button>
+            <button type="button" id="permalink" class="btn btn-sm btn-outline-primary float-right mx-2" title="Copy permalink to file" data-toggle="tooltip" data-placement="top"><i class="fas fa-link"></i></button>
           </div>
           <div id ="view-card-content" class="px-2 py-2 h-100">
             <div id='file-content' class="my-0 load-content" style="overflow-y: scroll;"></div>

--- a/seamm_dashboard/tests/test_views.py
+++ b/seamm_dashboard/tests/test_views.py
@@ -216,8 +216,6 @@ class TestLiveServer:
 
         test_file_id = "root/job.out_anchor"
 
-        chrome_driver.get(f"{self.base_url}#jobs/1")
-
         # Initially, there should be nothing in the text box.
 
         initial_displayed_text = (
@@ -256,8 +254,12 @@ class TestLiveServer:
         """
         Test to click file and make sure it is loaded into div.
         """
-        # Have to log in for this
+
+         # Have to log in for this
         self.log_in(chrome_driver)
+
+        # Get page with chromedriver.
+        chrome_driver.get(f"{self.base_url}#jobs/1")
 
         # Set up sample file for comparison.
         test_file = os.path.realpath(
@@ -268,11 +270,10 @@ class TestLiveServer:
             file_contents = f.read()
             file_contents_split = file_contents.split()
 
-        test_file_id = urllib.parse.quote(test_file, safe="") + "_anchor"
-
-        chrome_driver.get(f"{self.base_url}#jobs/1")
+        test_file_id = "root/job.out_anchor"
 
         # Initially, there should be nothing in the text box.
+
         initial_displayed_text = (
             WebDriverWait(chrome_driver, 20)
             .until(EC.presence_of_element_located((By.ID, "file-content")))
@@ -285,7 +286,11 @@ class TestLiveServer:
         )
         job_link.click()
 
-        time.sleep(1)
+        # Give time to load
+        time.sleep(1.25)
+
+        # screenshot
+        # chrome_driver.get_screenshot_as_file(f"job_report.png")
 
         # When clicked, file text should be displayed in the div.
         displayed_text = chrome_driver.find_element(By.ID, "file-content").text
@@ -294,11 +299,11 @@ class TestLiveServer:
 
         # Splitting on whitespace and rejoining let's us compare the file
         # contents without worrying about how whitespace is handled.
-        assert initial_displayed_text == ""
+        assert initial_displayed_text == "", "initial displayed text error"
         assert " ".join(displayed_text_list) == " ".join(
             file_contents_split
-        ), "initial load failed."
-
+        ), "displayed text error"
+        
         # Update file on disk
         with open(test_file, "a+") as f:
             f.write("Appending this line")
@@ -333,10 +338,10 @@ class TestLiveServer:
         )
         second_file = os.path.realpath(
             os.path.join(project_directory, "Job_000001", "flowchart.flow")
-        )
+        )   
 
-        first_file_id = urllib.parse.quote(first_file, safe="") + "_anchor"
-        second_file_id = urllib.parse.quote(second_file, safe="") + "_anchor"
+        first_file_id =  "root/job.out_anchor"
+        second_file_id = "root/flowchart.flow_anchor"
 
         chrome_driver.get(f"{self.base_url}#jobs/1")
 

--- a/seamm_dashboard/tests/test_views.py
+++ b/seamm_dashboard/tests/test_views.py
@@ -202,6 +202,9 @@ class TestLiveServer:
         # Have to log in for this
         self.log_in(chrome_driver)
 
+        # Get page with chromedriver.
+        chrome_driver.get(f"{self.base_url}#jobs/1")
+
         # Set up sample file for comparison.
         test_file = os.path.realpath(
             os.path.join(project_directory, "Job_000001", "job.out")
@@ -211,7 +214,7 @@ class TestLiveServer:
             file_contents = f.read()
             file_contents_split = file_contents.split()
 
-        test_file_id = urllib.parse.quote(test_file, safe="") + "_anchor"
+        test_file_id = "root/job.out_anchor"
 
         chrome_driver.get(f"{self.base_url}#jobs/1")
 


### PR DESCRIPTION
This PR adds the ability to create a link directly to particular files in jobs. 

A button is added over the job view which will copy a link to the user's clipboard:

![circled_link](https://user-images.githubusercontent.com/18010556/191804592-5618e5ca-5f2b-413a-946b-db6243a1e044.png)

The copied URL can be used to open a page which will display the file of interest when clicked:

![using_link](https://user-images.githubusercontent.com/18010556/191804711-3f8e4a68-6aac-47dc-b0ff-8f1f634225a3.png)


This allows users to directly link collaborators to files they want to see. 

This PR also puts in place the machinery needed to load data on the page from a `job_report.html` file.
