### PR TITLE
remove unneeded testing dependency

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -41,6 +41,4 @@ dependencies:
   - nodejs
   - twine
   
-  - pip:
-    # For testing:
-    - pytest-selenium
+


### PR DESCRIPTION
An unneeded dependency in the testing environment is causing tests to fail. This PR removes that dependency (or that's my assessment of the situation so far, we'll see if the tests pass!)