### PR TITLE
pins sqlalchemy version

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - seamm-datastore
   - seamm-util
   - six
-  - sqlalchemy
+  - sqlalchemy<2.0
   - swagger-ui-bundle
   - wtforms
   - flask-compress

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ flask-wtf
 seamm-datastore
 seamm-util
 six
-sqlalchemy
+sqlalchemy<2.0
 swagger-ui-bundle
 wtforms
 flask-compress


### PR DESCRIPTION
marshmallow-sqlalchemy is not yet updated for sqlalchemy 2.0, so we need to pin sqlalchemy in the requirements for now.