### PR TITLE
Added display of the structure to surfaces from cube files.

### DIFF
--- a/seamm_dashboard/routes/api/jobs.py
+++ b/seamm_dashboard/routes/api/jobs.py
@@ -44,6 +44,7 @@ file_icons = {
     "pdb": "fas fa-cubes",
     "mmcif": "fas fa-cubes",
     "cif": "fas fa-cubes",
+    "sdf": "fas fa-cubes",
     "cube": "fas fa-cube",
 }
 

--- a/seamm_dashboard/static/js/job_report.js
+++ b/seamm_dashboard/static/js/job_report.js
@@ -455,6 +455,10 @@ var contentFunctions = {
         "load" : [loadStructure, "href"],
         "resize": "structure",
     },
+    "sdf": {
+        "load" : [loadStructure, "href"],
+        "resize": "structure",
+    },
     "cube": {
         "load" : [loadCube, "href"],
         "resize": "structure",

--- a/seamm_dashboard/static/js/job_report.js
+++ b/seamm_dashboard/static/js/job_report.js
@@ -338,12 +338,40 @@ function loadCube(URL) {
         if (representation == "default") {
             stage.loadFile(URL, {ext: fileExtension, compressed: compressed }).then(function (component) {
                 // add + and - surfaces
-                component.addRepresentation("surface", {color: "red"})
-                component.addRepresentation("surface", {color: "blue", negateIsolevel: true})
+                component.addRepresentation("surface", {
+		    color: "red",
+		    opacity: 0.7,
+		    opaqueBack: false
+		})
+                component.addRepresentation("surface", {
+		    color: "blue",
+		    negateIsolevel: true,
+		    opacity: 0.7,
+		    opaqueBack: false
+		})
                 // provide a "good" view of the structure
                 component.autoView();
             });;
         }
+
+	// Read in "structure.sdf" to display the molecule
+	let n = URL.lastIndexOf("%2F")
+	let URLsdf = ""
+	if (n > 0) {
+	    URLsdf = URL.slice(0, n + 3)
+	} else {
+	    n = URL.lastIndexOf("=")
+	    URLsdf = URL.slice(0, n + 1)
+	}
+	URLsdf +=  "structure.sdf"
+	try {
+            stage.loadFile(URLsdf, {defaultRepresentation: true, ext: "sdf" }).then(function (component) {
+                component.autoView()
+            })
+	} catch {
+	    console.log("Error in loadCube getting 'structure.sdf'.")
+	}
+
         return stage
     }
 


### PR DESCRIPTION
If and only if there is a file 'structure.sdf' at the same level as the cube files, use it to add the display of the structure to plot of the orbital or density surfaces. Also made the surfaces somewhat transparent so that the structure is visible even if encased in e.g. the density.
![ethylene HOMO](https://github.com/molssi-seamm/seamm_dashboard/assets/23222468/d056c4d9-0f37-430b-b2ba-1a9073810c3a)
