### PR TITLE
adds jsonify to API routes

### DIFF
--- a/seamm_dashboard/routes/api/auth.py
+++ b/seamm_dashboard/routes/api/auth.py
@@ -79,7 +79,7 @@ def get_auth_token(body):
 
 
 def remove_auth_token():
-    resp = make_response({"logout": True})
+    resp = make_response(jsonify({"logout": True}))
     unset_jwt_cookies(resp)
     return resp, 200
 

--- a/seamm_dashboard/routes/api/flowcharts.py
+++ b/seamm_dashboard/routes/api/flowcharts.py
@@ -4,7 +4,7 @@ API calls for flowcharts
 
 from seamm_datastore.database.models import Flowchart
 from seamm_datastore.database.schema import FlowchartSchema
-from flask import Response
+from flask import Response, jsonify
 from flask_jwt_extended import jwt_required
 
 from seamm_dashboard import authorize
@@ -44,7 +44,7 @@ def get_flowcharts(description=None, limit=None):
 
     flowcharts_schema = FlowchartSchema(many=True)
 
-    return flowcharts_schema.dump(authorized_flowcharts), 200
+    return jsonify(flowcharts_schema.dump(authorized_flowcharts)), 200
 
 
 @jwt_required(optional=True)
@@ -75,7 +75,7 @@ def get_flowchart(id):
         return Response(status=401)
 
     flowchart_schema = FlowchartSchema(many=False)
-    return flowchart_schema.dump(flowchart), 200
+    return jsonify(flowchart_schema.dump(flowchart)), 200
 
 
 @jwt_required(optional=True)
@@ -140,4 +140,4 @@ def get_cytoscape(id, flowchartKeys=None):
         }
 
         elements.append(edge_data)
-    return elements, 201
+    return jsonify(elements), 201

--- a/seamm_dashboard/routes/api/groups.py
+++ b/seamm_dashboard/routes/api/groups.py
@@ -2,6 +2,8 @@
 API endpoint for groups
 """
 
+from flask import jsonify
+
 from flask_jwt_extended import jwt_required
 
 from seamm_dashboard import authorize
@@ -24,4 +26,4 @@ def get_groups():
     # for i, group in enumerate(groups):
     #    group["usernames"] = usernames[i]
 
-    return groups, 200
+    return jsonify(groups), 200

--- a/seamm_dashboard/routes/api/jobs.py
+++ b/seamm_dashboard/routes/api/jobs.py
@@ -13,7 +13,7 @@ import re
 import urllib.parse
 import tempfile
 
-from flask import send_from_directory, Response, request
+from flask import send_from_directory, Response, request, jsonify
 from flask_jwt_extended import jwt_required, get_current_user
 
 from seamm_dashboard import db, datastore, options
@@ -77,7 +77,7 @@ def get_jobs(
 
     jobs = JobSchema(many=True).dump(jobs)
 
-    return jobs
+    return jsonify(jobs), 200
 
 
 def get_job_id(filename):
@@ -224,7 +224,7 @@ def add_job(body):
 
     job = JobSchema(many=False).dump(job)
 
-    return job, 201
+    return jsonify(job), 201
 
 
 @jwt_required(optional=True)
@@ -251,7 +251,7 @@ def get_job(id):
         return Response(status=404)
 
     job_schema = JobSchema(many=False)
-    return job_schema.dump(job), 200
+    return jsonify(job_schema.dump(job)), 200
 
 
 @jwt_required(optional=True)
@@ -413,7 +413,7 @@ def get_job_files(id):
                     "icon": file_icons["folder"],
                 }
             )
-    return js_tree
+    return jsonify(js_tree), 200
 
 
 @jwt_required(optional=True)

--- a/seamm_dashboard/routes/api/roles.py
+++ b/seamm_dashboard/routes/api/roles.py
@@ -2,6 +2,8 @@
 API endpoint for groups
 """
 
+from flask import jsonify
+
 from flask_jwt_extended import jwt_required
 
 from seamm_dashboard import authorize
@@ -19,4 +21,4 @@ def get_roles():
 
     roles = role_schema.dump(roles)
 
-    return roles, 200
+    return jsonify(roles), 200

--- a/seamm_dashboard/routes/api/status.py
+++ b/seamm_dashboard/routes/api/status.py
@@ -3,6 +3,8 @@ API calls for the status
 """
 import logging
 
+from flask import jsonify
+
 from seamm_dashboard.setup_argparsing import options
 from seamm_datastore.database.models import Project, Job, Flowchart
 from seamm_datastore.database.schema import RoleSchema
@@ -74,4 +76,4 @@ def status():
         "projects": num_projects,
     }
 
-    return status, 200
+    return jsonify(status), 200


### PR DESCRIPTION
This adds `jsonify` to the API routes. There is a warning on our current version of flask that states this will be necessary in an upcoming version of flask (this version is out already, actually, but our dependencies haven't caught up).