### PR TITLE
Change connexion pinning in test-env

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,10 +4,10 @@ channels:
 dependencies:
   - pip
   - python
-  - connexion<3.0
+  - connexion>2.7,<3.0
   - email-validator
   - fasteners
-  - flask<3.0
+  - flask>2.0,<3.0
   - flask-authorize
   - flask-bootstrap
   - flask-cors


### PR DESCRIPTION
This PR changes the pinning for the connexion package so that the version is greater than 2.7